### PR TITLE
remove unneeded payout propery on Offer model

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,4 @@ Dockerfile*
 **/evoclick
 **/bin
 **/*.exe
-**/*.mti
+**/*.msi

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ next-env.d.ts
 **/evoclick
 **/bin
 **/*.exe
-**/*.mti
+**/*.msi

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,7 +134,6 @@ model Offer {
   id                 Int              @id @default(autoincrement())
   name               String
   url                String
-  payout             Int
   tags               String[]
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt

--- a/prisma/seedData.ts
+++ b/prisma/seedData.ts
@@ -13,7 +13,6 @@ export type TAffiliateNetworkSeedData = typeof affiliateNetworkSeedData;
 export const offerSeedData = {
     name: "My First Offer",
     url: "http://localhost:3001/public/sample-offer.html",
-    payout: 80,
     tags,
 };
 export type TOfferSeedData = typeof offerSeedData;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -89,7 +89,6 @@ export const offersSchema: z.ZodType<TOffer> = z.object({
     id: z.number(),
     name: z.string(),
     url: z.string(),
-    payout: z.number(),
     tags: z.array(z.string()),
     createdAt: z.date(),
     updatedAt: z.date(),

--- a/src/lib/shemas.test.ts
+++ b/src/lib/shemas.test.ts
@@ -141,7 +141,6 @@ describe("Testing schemas", () => {
             id: 7,
             name: "My Offer",
             url: "https://example.com/offer",
-            payout: 120,
             tags: ["my", "offer"],
             createdAt: new Date(),
             updatedAt: new Date(),

--- a/src/views/ReportView/ActionMenu/ActionMenuBody/OfferBody.tsx
+++ b/src/views/ReportView/ActionMenu/ActionMenuBody/OfferBody.tsx
@@ -24,15 +24,14 @@ export default function OfferBody({ actionMenu, setActionMenu }: {
 
     async function handleSave() {
         try {
-            const { id, name, url, payout, tags, affiliateNetworkId } = actionMenu;
+            const { id, name, url, tags, affiliateNetworkId } = actionMenu;
             if (typeof id === "number") {
-                await updateOfferAction(id, { name, url, payout, tags, affiliateNetworkId }, window.location.href);
+                await updateOfferAction(id, { name, url, tags, affiliateNetworkId }, window.location.href);
                 toast.success("Offer was updated successfully");
             } else if (affiliateNetworkId !== undefined) {
                 await createNewOfferAction({
                     name: name ?? "",
                     url: url ?? "",
-                    payout: payout ?? 0,
                     tags: tags ?? [],
                     affiliateNetworkId: affiliateNetworkId,
                 }, window.location.href);
@@ -70,11 +69,6 @@ export default function OfferBody({ actionMenu, setActionMenu }: {
                 name="URL"
                 value={actionMenu.url || ""}
                 onChange={e => setActionMenu({ ...actionMenu, url: e.target.value })}
-            />
-            <Input
-                name="Payout"
-                value={actionMenu.payout || 0}
-                onChange={e => setActionMenu({ ...actionMenu, payout: Number(e.target.value) || 0 })}
             />
             <TagsInput
                 title="Tags"

--- a/src/views/ReportView/ActionMenu/types.ts
+++ b/src/views/ReportView/ActionMenu/types.ts
@@ -62,7 +62,6 @@ export type TOfferActionMenu = {
     id?: number;
     name?: string;
     url?: string;
-    payout?: number;
     tags?: string[];
     affiliateNetworkId?: number;
 };


### PR DESCRIPTION
Payout is handled via query param in the postback URL. This property is not needed on the Offer model.